### PR TITLE
Fixes #15 - Fixed zoom greater than 100%

### DIFF
--- a/panojs/PanoJS.js
+++ b/panojs/PanoJS.js
@@ -449,15 +449,15 @@ PanoJS.prototype.removeTileFromWell = function(tile) {
  * routine, delaying the appearance of the tile until it is fully
  * loaded, if configured to do so.
  */
-function forceImageSizeToFitScale(imageElement, scale) {
+function forceImageSizeToFitScale(tileImg, scale) {
 	if (scale != 1) {
       if (tileImg.naturalWidth && tileImg.naturalHeight && tileImg.naturalWidth>0 && tileImg.naturalHeight>0) {
-        imageElement.style.width = tileImg.naturalWidth*scale + 'px';
-        imageElement.style.height = tileImg.naturalHeight*scale + 'px';
+        tileImg.style.width = tileImg.naturalWidth*scale + 'px';
+        tileImg.style.height = tileImg.naturalHeight*scale + 'px';
       } else
       if (isIE() && tileImg.offsetWidth>0 && tileImg.offsetHeight>0) { // damn IE does not have naturalWidth ...
-        imageElement.style.width = tileImg.offsetWidth*scale + 'px';
-        imageElement.style.height = tileImg.offsetHeight*scale + 'px';
+        tileImg.style.width = tileImg.offsetWidth*scale + 'px';
+        tileImg.style.height = tileImg.offsetHeight*scale + 'px';
       }
     }
 }


### PR DESCRIPTION
In commit 84219bd84cfd9935f2be7c9055d28a4446ea2260, an optimization was
introduced for zoom greater than 100%.  That commit refactored a block of
code out into a separate function.  The function param "tileImg" was
partially renamed to "imageElement", but not entirely.

This commit changes all uses of "imageElement" back to "tileImg".
