### PR TITLE
Fix import for MacOSX

### DIFF
--- a/scripts/tilemaker.py
+++ b/scripts/tilemaker.py
@@ -12,7 +12,7 @@ License: Apache 2.0
 
 import math
 from os.path import split, splitext
-from PIL import Image
+import Image
 
 chatty_default = False
 background_default = "FFFFFF"


### PR DESCRIPTION
Import PIL does not work, you must import Image, see this stackoverflow post:

http://stackoverflow.com/questions/8863917/importerror-no-module-named-pil